### PR TITLE
Make simulation log and input files changable from toplevel

### DIFF
--- a/bench/verilog/sdModel.v
+++ b/bench/verilog/sdModel.v
@@ -58,7 +58,9 @@
 `define RCV 6
 `define DATAS 5
 `define TRAN 4
-module sdModel(
+module sdModel
+#(parameter ramdisk="",
+  parameter log_file="") (
   input sdClk,
   tri cmd,
   tri [3:0] dat
@@ -178,7 +180,7 @@ reg [5:0] startUppCnt;
 
 reg q_start_bit;
 //Card initinCMd
-initial $readmemh("../bin/ramdisk2.hex",FLASHmem);
+initial $readmemh(ramdisk,FLASHmem);
 
 //integer k;
 //initial begin
@@ -944,7 +946,7 @@ integer sdModel_file_desc;
 
 initial
 begin
-  sdModel_file_desc = $fopen("../log/sd_model.log");
+  sdModel_file_desc = $fopen(log_file);
   if (sdModel_file_desc < 2)
   begin
     $display("*E Could not open/create testbench log file in /log/ directory!");

--- a/bench/verilog/sd_controller_top_tb.sv
+++ b/bench/verilog/sd_controller_top_tb.sv
@@ -73,7 +73,13 @@
 `define CRD 16'h20
 `define CWD 16'h40
 
-module sd_controller_top_tb(
+module sd_controller_top_tb
+#(parameter ramdisk="../bin/ramdisk2.hex",
+  parameter sd_model_log_file="../log/sd_model.log",
+  parameter wb_m_mon_log_file={`LOG_DIR, "/sdc_tb_wb_m_mon.log"},
+  parameter wb_s_mon_log_file={`LOG_DIR, "/sdc_tb_wb_s_mon.log"},
+  parameter wb_memory_file={`BIN_DIR, "/wb_memory.txt"})
+(
 
 );
 
@@ -114,7 +120,8 @@ tri [3:0] sd_dat;
 assign sd_cmd = sd_cmd_oe ? cmdIn: 1'bz;
 assign sd_dat =  sd_dat_oe  ? datIn : 4'bz;
 
-sdModel sdModelTB0(
+sdModel #(.ramdisk (ramdisk),
+	  .log_file (sd_model_log_file)) sdModelTB0(
     .sdClk(sd_clk_pad_o),
     .cmd(sd_cmd),
     .dat(sd_dat)
@@ -171,7 +178,9 @@ WB_MASTER_BEHAVIORAL wb_master0(
     .CAB_O() //Not in use
     );
 
-WB_SLAVE_BEHAVIORAL wb_slave0(
+WB_SLAVE_BEHAVIORAL
+  #(.wb_memory_file (wb_memory_file))
+   wb_slave0(
     .CLK_I(wb_clk),
     .RST_I(wb_rst),
     .ACK_O(wbm_sdm_ack_i),
@@ -232,14 +241,14 @@ WB_BUS_MON sdc_eth_master_bus_mon0(
 
 task open_log_files;
     begin
-        wb_s_mon_log_file_desc = $fopen({`LOG_DIR, "/sdc_tb_wb_s_mon.log"});
+        wb_s_mon_log_file_desc = $fopen(wb_s_mon_log_file);
         assert(wb_s_mon_log_file_desc >= 2);
         $fdisplay(wb_s_mon_log_file_desc, "============== WISHBONE Slave Bus Monitor error log ==============");
         $fdisplay(wb_s_mon_log_file_desc, " ");
         $fdisplay(wb_s_mon_log_file_desc, "   Only ERRONEOUS conditions are logged !");
         $fdisplay(wb_s_mon_log_file_desc, " ");
 
-        wb_m_mon_log_file_desc = $fopen({`LOG_DIR, "/sdc_tb_wb_m_mon.log"});
+        wb_m_mon_log_file_desc = $fopen(wb_m_mon_log_file);
         assert(wb_m_mon_log_file_desc >= 2);
         $fdisplay(wb_m_mon_log_file_desc, "============= WISHBONE Master Bus Monitor  error log =============");
         $fdisplay(wb_m_mon_log_file_desc, " ");

--- a/bench/verilog/wb_slave_behavioral.v
+++ b/bench/verilog/wb_slave_behavioral.v
@@ -58,6 +58,7 @@
 
 `include "wb_model_defines.h"
 module WB_SLAVE_BEHAVIORAL
+#(parameter wb_memory_file="")
 (
 	CLK_I,
 	RST_I,
@@ -101,7 +102,7 @@ reg     `WB_DATA_TYPE wb_memory [0:1048575]; // WB memory - 20 addresses connect
 reg     `WB_DATA_TYPE mem_wr_data_out;
 reg     `WB_DATA_TYPE mem_rd_data_in;
 
-initial $readmemh({`BIN_DIR, "/wb_memory.txt"},wb_memory);
+initial $readmemh(wb_memory_file,wb_memory);
 
 
 /*------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This makes it possible to override the default file names and locations
for build systems that uses other working directories
