### PR TITLE
Fixes

### DIFF
--- a/SD-card-controller-0-r2.core
+++ b/SD-card-controller-0-r2.core
@@ -1,0 +1,92 @@
+CAPI=2:
+
+name : ::SD-card-controller:0-r2
+
+filesets:
+  rtl:
+    files:
+      - rtl/verilog/sd_data_xfer_trig.v
+      - rtl/verilog/sd_crc_16.v
+      - rtl/verilog/generic_fifo_dc_gray.v
+      - rtl/verilog/sd_clock_divider.v
+      - rtl/verilog/sd_cmd_master.v
+      - rtl/verilog/sd_crc_7.v
+      - rtl/verilog/sd_cmd_serial_host.v
+      - rtl/verilog/generic_dpram.v
+      - rtl/verilog/sdc_controller.v
+      - rtl/verilog/monostable_domain_cross.v
+      - rtl/verilog/sd_wb_sel_ctrl.v
+      - rtl/verilog/sd_data_serial_host.v
+      - rtl/verilog/sd_controller_wb.v
+      - rtl/verilog/sd_data_master.v
+      - rtl/verilog/bistable_domain_cross.v
+      - rtl/verilog/sd_fifo_filler.v
+      - rtl/verilog/byte_en_reg.v
+      - rtl/verilog/edge_detect.v
+      - rtl/verilog/sd_defines.h : {is_include_file : true}
+    file_type: verilogSource
+
+  tb:
+    files:
+      - bench/verilog/byte_en_reg_tb.sv
+      - bench/verilog/sd_cmd_serial_host_tb.sv
+      - bench/verilog/sdModel.v
+      - bench/verilog/monostable_domain_cross_tb.sv
+      - bench/verilog/sd_cmd_master_tb.sv
+      - bench/verilog/sd_data_master_tb.sv
+      - bench/verilog/wb_master32.v
+      - bench/verilog/sd_fifo_filler_tb.sv
+      - bench/verilog/bistable_domain_cross_tb.sv
+      - bench/verilog/wb_master_behavioral.v : {file_type : verilogSource}
+      - bench/verilog/sd_controller_wb_tb.sv
+      - bench/verilog/wb_bus_mon.v
+      - bench/verilog/sd_wb_sel_ctrl_tb.sv
+      - bench/verilog/edge_detect_tb.sv
+      - bench/verilog/wb_slave_behavioral.v
+      - bench/verilog/sd_data_xfer_trig_tb.sv
+      - bench/verilog/sd_data_serial_host_tb.sv
+      - bench/verilog/sd_controller_top_tb.sv
+      - bench/verilog/wb_model_defines.h : {is_include_file : true}
+      - sim/rtl_sim/bin/ramdisk2.hex  : {file_type : user, copyto: ramdisk2.hex}
+      - sim/rtl_sim/bin/wb_memory.txt : {file_type : user, copyto : wb_memory.txt}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets : [rtl]
+  tb:
+    default_tool: modelsim
+    filesets: [rtl, tb]
+    parameters : [ramdisk, sd_model_log_file, wb_m_mon_log_file, wb_s_mon_log_file, wb_memory_file]
+    toplevel : sd_controller_top_tb
+
+parameters:
+  ramdisk:
+    datatype    : file
+    default     : ramdisk2.hex
+    description : Initial simulated SD card contents (in Verilog hex format)
+    paramtype   : vlogparam
+
+  sd_model_log_file:
+    datatype    : file
+    default     : sd_model.log
+    description : Log file for SD card model
+    paramtype   : vlogparam
+
+  wb_m_mon_log_file:
+    datatype    : file
+    default     : wb_m_mon.log
+    description : Master monitor log file
+    paramtype   : vlogparam
+
+  wb_s_mon_log_file:
+    datatype    : file
+    default     : wb_s_mon.log
+    description : Slave monitor log file
+    paramtype   : vlogparam
+
+  wb_memory_file:
+    datatype    : file
+    default     : wb_memory.txt
+    description : Initial simulated Wishbone memory contents (in Verilog hex format)
+    paramtype   : vlogparam

--- a/bench/verilog/edge_detect_tb.sv
+++ b/bench/verilog/edge_detect_tb.sv
@@ -51,7 +51,7 @@ reg sig;
 wire rise;
 wire fall;
 
-edge_detect edge_detect_dut(
+sd_edge_detect edge_detect_dut(
     .rst(rst),
     .clk(clk),
     .sig(sig), 

--- a/bench/verilog/sdModel.v
+++ b/bench/verilog/sdModel.v
@@ -384,6 +384,8 @@ always @ (posedge sdClk) begin
    qCmd<=cmd;
 end
 
+integer sdModel_file_desc;
+
 //read data and cmd on rising edge
 always @ (posedge sdClk) begin
  case(state)
@@ -941,8 +943,6 @@ always @ (negedge sdClk) begin
   end
 endcase
 end
-
-integer sdModel_file_desc;
 
 initial
 begin

--- a/bench/verilog/sd_controller_top_tb.sv
+++ b/bench/verilog/sd_controller_top_tb.sv
@@ -114,7 +114,7 @@ wire sd_cmd_oe;
 wire sd_dat_oe;
 wire cmdIn;
 wire [3:0] datIn;
-trireg sd_cmd;
+tri sd_cmd;
 tri [3:0] sd_dat;
 
 assign sd_cmd = sd_cmd_oe ? cmdIn: 1'bz;

--- a/rtl/verilog/edge_detect.v
+++ b/rtl/verilog/edge_detect.v
@@ -42,7 +42,7 @@
 ////                                                              ////
 //////////////////////////////////////////////////////////////////////
 
-module edge_detect (
+module sd_edge_detect (
     input rst,
     input clk, 
     input sig,

--- a/rtl/verilog/generic_dpram.v
+++ b/rtl/verilog/generic_dpram.v
@@ -101,7 +101,7 @@
 
 module generic_dpram(
 	// Generic synchronous dual-port RAM interface
-	rclk, rrst, rce, oe, raddr, do,
+	rclk, rrst, rce, oe, raddr, dout,
 	wclk, wrst, wce, we, waddr, di
 );
 
@@ -120,7 +120,7 @@ module generic_dpram(
 	input           rce;   // read port chip enable, active high
 	input           oe;	   // output enable, active high
 	input  [aw-1:0] raddr; // read address
-	output [dw-1:0] do;    // data output
+	output [dw-1:0] dout;  // data output
 
 	// write port
 	input          wclk;  // write clock, rising edge trigger
@@ -149,7 +149,7 @@ module generic_dpram(
 	  if (rce)
 	    ra <= raddr;
 
-	assign do = mem[ra];
+	assign dout = mem[ra];
 
 	// write operation
 	always@(posedge wclk)
@@ -172,7 +172,7 @@ module generic_dpram(
 		.ADDRA(raddr),
 		.DIA( {dw{1'b0}} ),
 		.WEA(1'b0),
-		.DOA(do),
+		.DOA(dout),
 
 		// write port
 		.CLKB(wclk),
@@ -201,7 +201,7 @@ module generic_dpram(
 		.rdclock(rclk),
 		.rdclocken(rce),
 		.rdaddress(raddr),
-		.q(do),
+		.q(dout),
 
 		// write port
 		.wrclock(wclk),
@@ -226,7 +226,7 @@ module generic_dpram(
 	//
 	art_hsdp #(dw, 1<<aw, aw) artisan_sdp(
 		// read port
-		.qa(do),
+		.qa(dout),
 		.clka(rclk),
 		.cena(~rce),
 		.wena(1'b1),
@@ -262,7 +262,7 @@ module generic_dpram(
 		.ra(raddr),
 		.wa(waddr),
 		.di(di),
-		.do(do)
+		.do(dout)
 	);
 
 `else
@@ -282,7 +282,7 @@ module generic_dpram(
 		.DA( {dw{1'b0}} ),
 		.WEA(1'b0),
 		.OEA(oe),
-		.QA(do),
+		.QA(dout),
 
 		// write port
 		.CLKB(wclk),
@@ -309,7 +309,7 @@ module generic_dpram(
 	//
 	// Data output drivers
 	//
-	assign do = (oe & rce) ? do_reg : {dw{1'bz}};
+	assign dout = (oe & rce) ? do_reg : {dw{1'bz}};
 
 	// read operation
 	always @(posedge rclk)

--- a/rtl/verilog/generic_fifo_dc_gray.v
+++ b/rtl/verilog/generic_fifo_dc_gray.v
@@ -209,7 +209,7 @@ generic_dpram  #(aw,dw) u0(
 	.rce(		1'b1		),
 	.oe(		1'b1		),
 	.raddr(		rp_bin[aw-1:0]	),
-	.do(		dout		),
+	.dout(		dout		),
 	.wclk(		wr_clk		),
 	.wrst(		!wr_rst		),
 	.wce(		1'b1		),

--- a/rtl/verilog/sd_data_serial_host.v
+++ b/rtl/verilog/sd_data_serial_host.v
@@ -192,6 +192,7 @@ begin: FSM_OUT
         data_index <= 0;
         next_block <= 0;
         blkcnt_reg <= 0;
+        blksize_reg <= 0;
         byte_alignment_reg <= 0;
         data_cycles <= 0;
         bus_4bit_reg <= 0;      

--- a/rtl/verilog/sdc_controller.v
+++ b/rtl/verilog/sdc_controller.v
@@ -396,9 +396,9 @@ sd_controller_wb sd_controller_wb0(
 //assign dma_addr_reg_sd_clk = dma_addr_reg_wb_clk;
 //assign data_int_status_reg_wb_clk = data_int_status_reg_sd_clk;
 
-edge_detect cmd_start_edge(.rst(wb_rst_i), .clk(wb_clk_i), .sig(cmd_start), .rise(cmd_start_wb_clk), .fall());
-edge_detect data_int_rst_edge(.rst(wb_rst_i), .clk(wb_clk_i), .sig(data_int_rst), .rise(data_int_rst_wb_clk), .fall());
-edge_detect cmd_int_rst_edge(.rst(wb_rst_i), .clk(wb_clk_i), .sig(cmd_int_rst), .rise(cmd_int_rst_wb_clk), .fall());
+sd_edge_detect cmd_start_edge(.rst(wb_rst_i), .clk(wb_clk_i), .sig(cmd_start), .rise(cmd_start_wb_clk), .fall());
+sd_edge_detect data_int_rst_edge(.rst(wb_rst_i), .clk(wb_clk_i), .sig(data_int_rst), .rise(data_int_rst_wb_clk), .fall());
+sd_edge_detect cmd_int_rst_edge(.rst(wb_rst_i), .clk(wb_clk_i), .sig(cmd_int_rst), .rise(cmd_int_rst_wb_clk), .fall());
 monostable_domain_cross cmd_start_cross(wb_rst_i, wb_clk_i, cmd_start_wb_clk, sd_clk_o, cmd_start_sd_clk);
 monostable_domain_cross data_int_rst_cross(wb_rst_i, wb_clk_i, data_int_rst_wb_clk, sd_clk_o, data_int_rst_sd_clk);
 monostable_domain_cross cmd_int_rst_cross(wb_rst_i, wb_clk_i, cmd_int_rst_wb_clk, sd_clk_o, cmd_int_rst_sd_clk);


### PR DESCRIPTION
This contains a couple of different fixes and adds FuseSoC support
- Properly reset blksize_reg to avoid a latch
- Rename do to dout to avoid conflict with SV keyword
- Rename edge_detect to sd_edge_detect to avoid conflict with other edge_detect modules
- Syntactic fixes to testbench to make it work with Vivado's Xsim simulator
- Adds FuseSoC support

To test the FuseSoC support, first install [fusesoc](https://github.com/olofk/fusesoc), then add SD-card-controller as a library
`fusesoc library add sdc /path/to/SD-card-controller`
Run the simulation with `fusesoc run --target=tb SD-card-controller`. By default it will use ModelSim. To use xsim instead, run `fusesoc run --target=tb --tool=xsim SD-card-controller`
